### PR TITLE
feat(docs): Exchange apostrophes in plugins to be smart

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -86,7 +86,7 @@ Extend your site with official plugins supported by the Starlight team and commu
 	<LinkCard
 		href="https://github.com/Fevol/starlight-site-graph"
 		title="starlight-site-graph"
-		description="Add an interactive site graph inside your page's sidebar."
+		description="Add an interactive site graph inside your page’s sidebar."
 	/>
 	<LinkCard
 		href="https://github.com/HiDeoo/starlight-sidebar-topics"
@@ -141,7 +141,7 @@ Extend your site with official plugins supported by the Starlight team and commu
 	<LinkCard
 		href="https://github.com/trueberryless-org/starlight-toc-overview-customizer"
 		title="starlight-toc-overview-customizer"
-		description="Tweak Starlight's table of contents with customizable overview title."
+		description="Tweak Starlight’s table of contents with customizable overview title."
 	/>
 	<LinkCard
 		href="https://delucis.github.io/starlight-markdown-blocks/"


### PR DESCRIPTION
As noticed in #2998 there are some plugins that use `'` (straight apostrophe) instead of (`’`) smart apostrophes.

This is probably unintentional by the author of the PRs adding these plugins and changed to be smart in this PR.

Reference: https://github.com/withastro/starlight/pull/2998#discussion_r2007808876